### PR TITLE
Add the Cols, Rows, and Print functions along with their documentation

### DIFF
--- a/mat/README.md
+++ b/mat/README.md
@@ -57,8 +57,8 @@ at a time. This results in some major inefficiencies, and it is recommended that
 this function be used sparingly, and not as a major component of your
 library/executable.
 
-Unlike other mat creation methods in this package, the capacity of the mat 
-object created here is the same as its length since we assume the mat to 
+Unlike other mat creation methods in this package, the capacity of the mat
+object created here is the same as its length since we assume the mat to
 be very large.
 
 #### func  FromSlice
@@ -244,6 +244,28 @@ Col returns a new mat object whole values are equal to a column of the original
 mat object. The number of Rows of the returned mat object is equal to the number
 of rows of the original mat, and the number of columns is equal to 1.
 
+
+#### func (m *Mat) Cols
+
+```go
+func (m *Mat) Cols() <-chan *Mat
+```
+Cols returns a generator which, upon invocation, returns the next column of a
+Mat in form of a Mat with 1 column, and the same number of rows of the method
+receiver. Consider the following:
+
+```go
+m := mat.New(3, 2).Inc()
+m.Print() // 0.0 1.0
+          // 2.0 3.0
+    	  // 4.0 5.0
+
+for col := range m.Cols() {
+    col.Print()
+}
+```
+
+
 #### func (m *Mat) Concat
 
 ```go
@@ -306,8 +328,6 @@ n := mat.New(6, 10)
 o := m.Dot(n)
 
 o.Dims() // (5, 10)
-
-o.At(i, j) == mat.Sum(m.Row(i).Mul(n.col(j))
 
 ```
 
@@ -385,6 +405,14 @@ func (m *Mat) Ones() *Mat
 ```
 Ones sets all values of a mat to be equal to 1.0
 
+
+#### func (m *Mat) Print
+
+```go
+func (m *Mat) Print()
+```
+Print displays the content of a Mat to the screen.
+
 #### func (m *Mat) Prod
 
 ```go
@@ -435,6 +463,27 @@ func (m *Mat) Row(x int) *Mat
 Row returns a new mat object whose values are equal to a row of the original mat
 object. The number of Rows of the returned mat object is equal to 1, and the
 number of columns is equal to the number of columns of the original mat.
+
+
+#### func (m *Mat) Rows
+
+```go
+func (m *Mat) Rows() <-chan *Mat
+```
+Rows returns a generator which, upon invocation, returns the next row of a Mat
+in form of a Mat with 1 row, and the same number of columns of the method
+receiver. Consider the following:
+
+```go
+m := mat.New(3, 2).Inc()
+m.Print() // 0.0 1.0
+          // 2.0 3.0
+    	  // 4.0 5.0
+
+for row := range m.Rows() {
+    row.Print()
+}
+```
 
 #### func (m *Mat) Scale
 

--- a/mat/mat.go
+++ b/mat/mat.go
@@ -44,7 +44,7 @@ type booleanFunc func(*float64) bool
 type reducerFunc func(accumulator, next *float64)
 
 /*
-New is the primary constructor for the "Mat" object. New is a veradic function,
+New is the primary constructor for the "Mat" object. New is a variadic function,
 expecting 0 to 3 ints, with differing behavior as follows:
 
 m := New()
@@ -247,8 +247,8 @@ at a time. This results in some major inefficiencies, and it is recommended
 that this function be used sparingly, and not as a major component of your
 library/executable.
 
-Unline other mat creation methods in this package, the mat object created here,
-the capacity of the mat opject created here is the same as its length since we
+Unlike other mat creation methods in this package, the mat object created here,
+the capacity of the mat object created here is the same as its length since we
 assume the mat to be very large.
 */
 func FromCSV(filename string) *Mat {
@@ -598,6 +598,46 @@ func (m *Mat) Col(x int) *Mat {
 }
 
 /*
+Cols returns a generator which, upon invocation, returns the next column of
+a Mat in form of a Mat with 1 column, and the same number of rows of the
+method receiver. Consider the following:
+
+m := mat.New(3, 2).Inc()
+m.Print() // 0.0 1.0
+          // 2.0 3.0
+		  // 4.0 5.0
+
+for col := range m.Cols() {
+	col.Print()
+}
+
+The col.Print() above prints:
+// 0.0
+// 2.0
+// 4.0
+
+and then
+// 1.0
+// 3.0
+// 5.0
+*/
+func (m *Mat) Cols() <-chan *Mat {
+	res := make(chan *Mat)
+	i := 0
+	go func(res chan *Mat) {
+		if i == m.c-1 {
+			res <- m.Col(i)
+			close(res)
+		} else {
+			res <- m.Col(i)
+			close(res)
+			i++
+		}
+	}(res)
+	return res
+}
+
+/*
 Row returns a new mat object whose values are equal to a row of the original
 mat object. The number of Rows of the returned mat object is equal to 1, and
 the number of columns is equal to the number of columns of the original mat.
@@ -617,6 +657,45 @@ func (m *Mat) Row(x int) *Mat {
 		v.vals[r] = m.vals[x*m.c+r]
 	}
 	return v
+}
+
+/*
+Rows returns a generator which, upon invocation, returns the next row of
+a Mat in form of a Mat with 1 row, and the same number of columns of the
+method receiver. Consider the following:
+
+m := mat.New(3, 2).Inc()
+m.Print() // 0.0 1.0
+          // 2.0 3.0
+		  // 4.0 5.0
+
+for row := range m.Rows() {
+	row.Print()
+}
+
+The col.Print() above prints:
+// 0.0 1.0
+
+and then
+// 2.0 3.0
+
+and finally
+// 4.0 5.0
+*/
+func (m *Mat) Rows() <-chan *Mat {
+	res := make(chan *Mat)
+	i := 0
+	go func(res chan *Mat) {
+		if i == m.r-1 {
+			res <- m.Row(i)
+			close(res)
+		} else {
+			res <- m.Row(i)
+			close(res)
+			i++
+		}
+	}(res)
+	return res
 }
 
 /*
@@ -875,7 +954,7 @@ Div is the element-wise dicition of a mat object by another which is passed
 to this method.
 
 The shape of the mat objects must be the same (same number or rows and columns)
-and the results of the element-wise divition is stored in the original
+and the results of the element-wise division is stored in the original
 mat on which the method was invoked. The dividing mat object (passed to this
 method) must not contain any elements which are equal to 0.0.
 */
@@ -1231,7 +1310,6 @@ func (m *Mat) ToString() string {
 
 /*
 AppendCol appends a column to the right side of a Mat.
-TODO: Fix this... the new object is not returned.
 */
 func (m *Mat) AppendCol(v []float64) *Mat {
 	if m.r != len(v) {
@@ -1317,4 +1395,11 @@ func (m *Mat) Concat(n *Mat) *Mat {
 		}
 	}
 	return m
+}
+
+/*
+Print displays the content of a Mat to the screen.
+*/
+func (m *Mat) Print() {
+	fmt.Println(m.ToString())
 }

--- a/mat/mat.go
+++ b/mat/mat.go
@@ -622,18 +622,13 @@ and then
 // 5.0
 */
 func (m *Mat) Cols() <-chan *Mat {
-	res := make(chan *Mat)
-	i := 0
-	go func(res chan *Mat) {
-		if i == m.c-1 {
+	res := make(chan *Mat, m.c)
+	go func() {
+		for i := 0; i < m.c; i++ {
 			res <- m.Col(i)
-			close(res)
-		} else {
-			res <- m.Col(i)
-			close(res)
-			i++
 		}
-	}(res)
+		close(res)
+	}()
 	return res
 }
 
@@ -683,18 +678,13 @@ and finally
 // 4.0 5.0
 */
 func (m *Mat) Rows() <-chan *Mat {
-	res := make(chan *Mat)
-	i := 0
-	go func(res chan *Mat) {
-		if i == m.r-1 {
+	res := make(chan *Mat, m.r)
+	go func() {
+		for i := 0; i < m.r; i++ {
 			res <- m.Row(i)
-			close(res)
-		} else {
-			res <- m.Row(i)
-			close(res)
-			i++
 		}
-	}(res)
+		close(res)
+	}()
 	return res
 }
 


### PR DESCRIPTION
This will add the rows and cols generators, such that we can iterate over the rows and columns of a Mat object. Misspellings are fixed as they are found.

The Print method was dropped somehow, so it is added here.
